### PR TITLE
Protect NPM Token During Pipeline Install

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,6 @@ jobs:
         env:
           NODE_ENV: "cicd"
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-          NPM_TOKEN: ${{secrets.npm_token}}
           GITHUB_TOKEN: ${{secrets.gh_token}}
           GIT_AUTHOR_NAME: "autocloud-deploy-bot"
           GIT_AUTHOR_EMAIL: "no-reply@autocloud.dev"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install Packages
-        run: yarn install --frozen-lockfile --prefer-offline
+        # NOTE: The --ignore-scripts flag is required to prevent leakage of NPM_TOKEN value
+        # See https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#use-private-packages
+        run: yarn install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Build
         run: yarn prepack


### PR DESCRIPTION
Follows Github's best practices to secure the NPM token during install phase of pipeline